### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,5 +162,5 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'org.greenrobot:eventbus:3.1.1'
-    implementation 'com.hold1:keyboardheightprovider:0.0.9'
+    implementation 'com.github.sergioroprado:KeyboardHeightProvider:1.0.4-Egemen'
 }


### PR DESCRIPTION
Since this project haven't migrated to AndroidX, the KeyboardHeightProvider dependency had to be replaced with another version without AndroidX, to avoid compilation errors.